### PR TITLE
docker-compose: get GITHUB_ACCESS_TOKEN from env, simpler_model.py bug fix 

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,4 +7,4 @@ services:
     ports:
       - 3000:3000
     environment:
-      - GITHUB_ACCESS_TOKEN=your_github_access_token
+      - GITHUB_ACCESS_TOKEN

--- a/fake_star_detector/assets/simpler_model.py
+++ b/fake_star_detector/assets/simpler_model.py
@@ -203,7 +203,7 @@ def _validate_star(row: pd.DataFrame) -> int:
         and (row["following"] < 2)
         and (row["public_gists"] == 0)
         and (row["public_repos"] < 5)
-        and (row["created_at"] > datetime.date(2022, 1, 1))
+        and (row["created_at"] > pd.Timestamp(datetime.date(2022, 1, 1)))
         and (row["email"] is None)
         and (row["bio"] is None)
         and (not row["blog"])


### PR DESCRIPTION
- docker-compose able to pass env variable value
- simpler_model.py just failed :( `comparing Timestamp with datetime.date.` , this is quick fix 